### PR TITLE
show img in shopping_list

### DIFF
--- a/rezappte/rezappte/doctype/einkaufsliste/einkaufsliste.py
+++ b/rezappte/rezappte/doctype/einkaufsliste/einkaufsliste.py
@@ -56,7 +56,8 @@ def get_ingredients(shopping_list_name):
                                     `tabRezept Zutaten`.`amount`,
                                     `tabRezept Zutaten`.`uom`,
                                     `tabRezept`.`persons_qty`,
-                                    `tabZutaten`.`abteilung`
+                                    `tabZutaten`.`abteilung`,
+                                    `tabZutaten`.`image`
                                 FROM
                                     `tabRezept Zutaten`
                                 LEFT JOIN
@@ -91,7 +92,13 @@ def calc_ingredients(ingredients):
                 found_match = True
                 existing_ingredient['amount'] += real_amount
         if not found_match:
-            calced_ingredients.append({'ingredient': actual_ingredient, 'amount': real_amount or 0, 'uom': main_uom, 'abteilung': ingredient.get('abteilung')})
+            calced_ingredients.append({
+                'ingredient': actual_ingredient,
+                'amount': real_amount or 0,
+                'uom': main_uom,
+                'abteilung': ingredient.get('abteilung'),
+                'image': ingredient.get('image')
+            })
 
     return calced_ingredients
                                     
@@ -130,7 +137,8 @@ def order_ingredients(ingredients):
                                                                         'ingredient': ingredient.get('ingredient'),
                                                                         'amount': ingredient.get('amount'),
                                                                         'uom': ingredient.get('uom'),
-                                                                        'html_id': get_html_id(length=12)
+                                                                        'html_id': get_html_id(length=12),
+                                                                        'image': ingredient.get('image')
                                                                     })
     frappe.log_error(ordered_ingredients, "ordered_ingredients")
     return ordered_ingredients

--- a/rezappte/rezappte/doctype/zutaten/zutaten.json
+++ b/rezappte/rezappte/doctype/zutaten/zutaten.json
@@ -7,6 +7,7 @@
  "field_order": [
   "namez",
   "uom",
+  "image",
   "column_break_3",
   "abteilung",
   "conversion_section",
@@ -49,9 +50,14 @@
    "fieldtype": "Table",
    "label": "Conversions",
    "options": "UOM Conversion"
+  },
+  {
+   "fieldname": "image",
+   "fieldtype": "Attach Image",
+   "label": "image"
   }
  ],
- "modified": "2024-08-06 21:48:53.381291",
+ "modified": "2024-08-29 20:16:00.309508",
  "modified_by": "Administrator",
  "module": "Rezappte",
  "name": "Zutaten",

--- a/rezappte/rezappte/page/shopping_list_display/shopping_list_display.html
+++ b/rezappte/rezappte/page/shopping_list_display/shopping_list_display.html
@@ -3,10 +3,11 @@
         <button class="accordion btn-{{ category }}">{{ category }}</button>
         <div class="panel">
             {% for ingredient in ingredients %}
-                    <div id="{{ ingredient.html_id }}" style="margin: 0px">
+                    <div id="{{ ingredient.html_id }}" style="margin: 0px width: 100%;">
                         <label>
-                            <input type="checkbox" class="{{ category }}" id="{{ ingredient.html_id }}_check" onclick="toggleLine(this)"> - {{ ingredient.amount }} {{ ingredient.uom }} {{ ingredient.ingredient }}
+                            <input type="checkbox" class="{{ category }}" id="{{ ingredient.html_id }}_check" onclick="toggleLine(this)"> - {{ ingredient.amount }} {{ ingredient.uom }} {{ ingredient.ingredient }}</input> 
                         </label>
+                        <i class="fa fa-eye pull-right" data-img="{{ ingredient.image }}" data-zutat="{{ ingredient.ingredient }}" onclick="show_img(this);"></i>
                     </div>
                 {% endfor %}
         </div>

--- a/rezappte/rezappte/page/shopping_list_display/shopping_list_display.js
+++ b/rezappte/rezappte/page/shopping_list_display/shopping_list_display.js
@@ -114,3 +114,12 @@ function unhide_category(category, ingredients) {
     }
     return false
 }
+
+function show_img(elmt) {
+    var img = $(elmt).data("img")!='None'?`<img src="${$(elmt).data("img")}">`:"<b>Kein</b> Bild vorhanden";
+    var zutat = $(elmt).data("zutat");
+    frappe.msgprint({
+        title: `${zutat}`,
+        message: img
+    });
+}


### PR DESCRIPTION
Zeigt pro Zutat in der Shopping-List ein Augen-Symbol an.
Beim klick darauf öffnet sich ein Pop-Up welches das Produktbild zeigt insofern eines vorhanden ist, wenn nicht kommt ein textlicher Hinweis.

Das Zutaten-Bild kann im DocType Zutat im Feld "Image" hinterlegt werden (achtung, muss Public sein).